### PR TITLE
PHP 8.0 curly braces is no longer supported

### DIFF
--- a/Route66.php
+++ b/Route66.php
@@ -68,7 +68,7 @@ class Route66 {
 					$rex = null;
 
 					if (isset($regs[$var])) {
-						if ($regs[$var]{0} == ':')
+						if ($regs[$var][0] == ':')
 							$typ = $regs[$var];
 						else
 							$rex = $regs[$var];


### PR DESCRIPTION
Array and string offset access syntax with curly braces is no longer supported. Just change to square brackets.